### PR TITLE
[FIX] 음식 검색 탭 식단 등록 로직 수정 #41

### DIFF
--- a/src/components/layout/AddFoodSheet.tsx
+++ b/src/components/layout/AddFoodSheet.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/navigation';
 import { Food } from '@/app/(pages)/home/MealCard';
 import { FoodData } from '@/types';
 import useDateStore from '@/zustand/dateStore';
+import moment from 'moment';
 
 const mealTypes: { [key: string]: { kr: string; en: string } } = {
   breakfast: { kr: '아침', en: 'breakfast' },
@@ -48,6 +49,11 @@ const AddFoodSheet: React.FC<Props> = ({ type, foodData, setIsOpened }) => {
   });
 
   const { getDate } = useDateStore();
+
+  // 탭 메뉴로 들어온 경우, 오늘 날짜를 기본값으로 설정
+  function getDay(day = 0) {
+    return moment().add(day, 'days').format('YYYY.MM.DD');
+  }
 
   // type이 있다면 currentIndex를 변경
   useEffect(() => {
@@ -123,7 +129,7 @@ const AddFoodSheet: React.FC<Props> = ({ type, foodData, setIsOpened }) => {
 
     const formData = {
       type: mealType,
-      title: getDate(),
+      title: type ? getDate() : getDay(),
       extra: {
         foodNm: name?.replaceAll('_', ' '),
         enerc: nutrient.enerc,
@@ -166,7 +172,9 @@ const AddFoodSheet: React.FC<Props> = ({ type, foodData, setIsOpened }) => {
     } catch (error) {
       console.error('식단 기록 오류', error);
     } finally {
-      router.push(`/meals/${mealTypeKeys[currentIndex]}/${getDate()}`);
+      router.push(
+        `/meals/${mealTypeKeys[currentIndex]}/${type ? getDate() : getDay()}`,
+      );
     }
   };
 


### PR DESCRIPTION
- 음식 검색 탭으로 들어갔을 경우 식단 등록은 당일만 가능하도록 수정 close #41

## #️⃣ 연관된 이슈

> #41

## ✅ PR 타입

> 하나 이상의 PR 타입을 선택해주세요.

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 작업 내용
-  이번 PR에서 작업한 내용을 간략히 설명해주세요.